### PR TITLE
Adding double quotations for _JAVACMD and CMD values.

### DIFF
--- a/gosu-core/src/main/java/gw/internal/gosu/parser/GosuProgramParser.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/GosuProgramParser.java
@@ -157,6 +157,10 @@ public class GosuProgramParser implements IGosuProgramParser
         name += "_" + fileContext.getContextString();
       }
 
+      if ( strSource.startsWith("\uFEFF") )
+      {
+        strSource = strSource.substring(1);
+      }
       StringSourceFileHandle sfh = new StringSourceFileHandle( name, strSource, false, ClassType.Program );
       if( fileContext != null )
       {

--- a/gosu/src/main/scripts/gosu
+++ b/gosu/src/main/scripts/gosu
@@ -45,8 +45,8 @@ for arg in "$@"; do
   _CMD_LINE_ARGS="$_CMD_LINE_ARGS \"$arg\""
 done
 
-CMD="exec $_JAVACMD $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
+CMD="exec \"$_JAVACMD\" $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
 if [ -n "$_DEBUG" ]; then
   echo $CMD $_CMD_LINE_ARGS
 fi
-eval $CMD $_CMD_LINE_ARGS
+eval "$CMD" $_CMD_LINE_ARGS


### PR DESCRIPTION
gosu script cannot display "gs>" prompt when JAVA_HOME path contains space character.

Steps to reproduce with gosu-0.10.2
1. Set JAVA_HOME to the path with space character from Terminal application on Mac OS X.
$ export JAVA_HOME="/Library/Internet Plug-Ins/JavaAppletPlugin.plugin/Contents/Home"
2. Launch gosu script

// actual result: Error is displayed on the shell script.
$ ./gosu-0.10.2/bin/gosu
gosu-0.10.2/bin/gosu: line 52: /Library/Internet: No such file or directory
gosu-0.10.2/bin/gosu: line 52: exec: /Library/Internet: cannot execute: No such file or directory
$ 

// expected result: Command prompt is displayed.
$ ./gosu-0.10.2/bin/gosu
Type "help" to see available commands
gs> 
