### PR TITLE
Issue64 Remove a byte order mark if strSource begins with BOM.

### DIFF
--- a/gosu-core/src/main/java/gw/internal/gosu/parser/GosuProgramParser.java
+++ b/gosu-core/src/main/java/gw/internal/gosu/parser/GosuProgramParser.java
@@ -157,6 +157,10 @@ public class GosuProgramParser implements IGosuProgramParser
         name += "_" + fileContext.getContextString();
       }
 
+      if ( strSource.startsWith("\uFEFF") )
+      {
+        strSource = strSource.substring(1);
+      }
       StringSourceFileHandle sfh = new StringSourceFileHandle( name, strSource, false, ClassType.Program );
       if( fileContext != null )
       {

--- a/gosu/src/main/scripts/gosu
+++ b/gosu/src/main/scripts/gosu
@@ -45,8 +45,8 @@ for arg in "$@"; do
   _CMD_LINE_ARGS="$_CMD_LINE_ARGS \"$arg\""
 done
 
-CMD="exec \"$_JAVACMD\" $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
+CMD="exec $_JAVACMD $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
 if [ -n "$_DEBUG" ]; then
   echo $CMD $_CMD_LINE_ARGS
 fi
-eval "$CMD" $_CMD_LINE_ARGS
+eval $CMD $_CMD_LINE_ARGS

--- a/gosu/src/main/scripts/gosu
+++ b/gosu/src/main/scripts/gosu
@@ -45,8 +45,8 @@ for arg in "$@"; do
   _CMD_LINE_ARGS="$_CMD_LINE_ARGS \"$arg\""
 done
 
-CMD="exec $_JAVACMD $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
+CMD="exec \"$_JAVACMD\" $_DEBUG $GOSU_OPTS -classpath \"$launcherApiJar:$launcherImplJar:$launcherAetherJar\" gw.lang.launch.impl.GosuLauncher -Dlauncher.properties.file=\"$_G_ROOT_DIR/bin/gosulaunch.properties\""
 if [ -n "$_DEBUG" ]; then
   echo $CMD $_CMD_LINE_ARGS
 fi
-eval $CMD $_CMD_LINE_ARGS
+eval "$CMD" $_CMD_LINE_ARGS


### PR DESCRIPTION
Fix for issue #64 "file encoding problem"
Steps to reproduce with gosu-0.10.2
1. Create test hello.gsp file with UTF-8 and BOM from Terminal application on Mac OS X
$ echo '\ufeffprint("hello!")' | native2ascii -encoding UTF-8 -reverse > hello.gsp
2. Run test file on Mac OS X or Windows
// expected result: Script displays output without exception.
$ ./bin/gosu -f hello.gsp 
hello!
// actual result: Exception is displayed as  
$ ./bin/gosu -f hello.gsp 
gw.lang.parser.exceptions.ParseResultsException: user.gosu-0.10.2.hello

Errors: 

No function defined for ﻿print. [line:3 col:1] in
line 2: 
Line Number: 1  Column: 1

```
at gw.internal.gosu.parser.ParserBase.verifyParsedElement(ParserBase.java:285)
at gw.internal.gosu.parser.ParserBase.verifyParsedElement(ParserBase.java:256)
at gw.internal.gosu.parser.GosuClassParser.parseDefinitions(GosuClassParser.java:458)
at gw.internal.gosu.parser.GosuClass.compileDefinitionsIfNeeded(GosuClass.java:1482)
at gw.internal.gosu.parser.GosuClass.compileDefinitionsIfNeeded(GosuClass.java:1423)
at gw.internal.gosu.parser.GosuClass.isValid(GosuClass.java:817)
at gw.internal.gosu.parser.GosuProgram_Proxy.isValid(gw.internal.gosu.parser.GosuProgram_Proxy:2)
at gw.internal.gosu.parser.GosuProgramParser.parseExpressionOrProgram(GosuProgramParser.java:188)
at gw.lang.Gosu$ExecuteMode.runWithFile(Gosu.java:766)
at gw.lang.Gosu$ExecuteMode.run(Gosu.java:723)
at gw.lang.Gosu.start(Gosu.java:123)
at gw.lang.launch.impl.GosuLauncher.run(GosuLauncher.java:143)
at gw.lang.launch.impl.GosuLauncher.main(GosuLauncher.java:63)
```
